### PR TITLE
fixed active requests tab browser console error msg

### DIFF
--- a/src/components/requests/ActiveRequests.jsx
+++ b/src/components/requests/ActiveRequests.jsx
@@ -12,7 +12,7 @@ import {
 import DeleteIcon from "@mui/icons-material/Delete";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 /* other imports */
-import { format, isPast } from "date-fns";
+import { format } from "date-fns";
 import axios from "axios";
 
 export default function ActiveRequests() {
@@ -88,7 +88,7 @@ export default function ActiveRequests() {
             <Typography>Completion Date: {date}</Typography>
             <Typography>Description: {el.description}</Typography>
             <Typography>Penalties: {el.endText}</Typography>
-            <Typography>Financial Penalties: {el.financialPenalty}</Typography>
+            <Typography>Financial Penalties: {el.financialPenalty?"Yes":"None"}</Typography>
           </ListItemText>
           {el.endIndicated && (
             <IconButton


### PR DESCRIPTION
- an error msg "Invalid prop `children` supplied to `ForwardRef(Typography)`, expected a ReactNode." was appearing when active requests tab opened
- traced it to <Typography>Financial Penalties: {el.financialPenalty}</Typography>
- el.financialPenalty is boolean, not a string, somehow tt got interpreted as trying to forward a ref
- error disappeared when line changed to <Typography>Financial Penalties: {el.financialPenalty?"Yes":"None"}</Typography>
- contents between <Typography> now a string rather than boolean value